### PR TITLE
Intorduced `IntoContext` and `ReportIntoContext` traits

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -652,6 +652,6 @@ mod test {
                 .into_ctx()
         }
 
-        let _ = output().unwrap_err();
+        assert!(output().is_err())
     }
 }


### PR DESCRIPTION
Added `IntoContext` trait, this allows type parameter conversion of `Report<T>` to `Report<U>`.
This allows a method that infers a type argument `report.into_ctx()` instead of the old explicit approach: `report.change_context(MyError)`:
https://github.com/knox-networks/bigerror/blob/4add13cc4401972a6b0d28e22d670bad34509055/src/lib.rs#L637-L641


* Added `ResultIntoContext` to handle `Result<_, Report<T>> to Result<_, Report<U>>` type conversions.
* Added `<T as Reportable>::value` method that allows us to return `Self`
* Renamed `ToErrReport` to `ResultToReport` to be consistent with upstream [`Result` impls](https://docs.rs/error-stack/latest/error_stack/trait.ResultExt.html)