### PR TITLE
Add `expect_field!` macro

### DIFF
--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -25,15 +25,6 @@ pull_request_rules:
           Approved by: @{{ approved_reviews_by | join(', @') }}
           ============
           {{ body }}
-          ============
-          {% set authors = [] %}
-          {%- for commit in commits if (commit.author,commit.email_author) not in authors
-          and not commit.author.startswith('mergify') %}
-          {{- authors.append((commit.author, commit.email_author)) or "" -}}
-          {% endfor %}
-          {%- for (author, email) in authors if authors|length > 1 -%}
-          Co-Authored-By: {{ author }} <{{ email }}>
-          {% endfor %}
 
   - name: cleanup post-merge
     conditions:

--- a/.mergify/config.yml
+++ b/.mergify/config.yml
@@ -18,6 +18,7 @@ pull_request_rules:
       queue:
         name: default
         method: squash
+        allow_merging_configuration_change: true
         # https://docs.mergify.com/configuration/#template
         commit_message_template: |
           {{ title }} (#{{ number }})

--- a/justfile
+++ b/justfile
@@ -7,3 +7,7 @@ _default:
 fmt:
     rustup run nightly cargo fmt -- \
       --config-path ./fmt/rustfmt.toml
+
+# Prints the error stack for a given test to stdout
+printerr test $PRINTERR="true":
+  @cargo test --quiet --lib -- --exact {{test}} --nocapture

--- a/justfile
+++ b/justfile
@@ -11,3 +11,6 @@ fmt:
 # Prints the error stack for a given test to stdout
 printerr test $PRINTERR="true":
   @cargo test --quiet --lib -- --exact {{test}} --nocapture
+
+printerr-all $PRINTERR="true":
+  @cargo test --quiet --lib -- --exact --nocapture

--- a/src/context.rs
+++ b/src/context.rs
@@ -42,6 +42,16 @@ pub struct DbError;
 reportable!(DbError);
 
 #[derive(Debug, thiserror::Error)]
+#[error("FsError")]
+pub struct FsError;
+reportable!(FsError);
+
+#[derive(Debug, thiserror::Error)]
+#[error("SetupError")]
+pub struct SetupError;
+reportable!(SetupError);
+
+#[derive(Debug, thiserror::Error)]
 #[error("ConversionError")]
 pub struct ConversionError;
 reportable!(ConversionError);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -900,8 +900,6 @@ mod test {
     #[test]
     #[should_panic]
     fn error_in_error_handling() {
-        crate::init_colour();
-
         fn output() -> Result<usize, Report<ConversionError>> {
             "NaN"
                 .parse::<usize>()
@@ -965,8 +963,6 @@ mod test {
 
     #[test]
     fn with_type_status() {
-        crate::init_colour();
-
         fn try_even(num: usize) -> Result<(), Report<MyError>> {
             if num % 2 != 0 {
                 return Err(InvalidInput::with_type_status::<usize>(Invalid).into_ctx());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -840,14 +840,14 @@ mod test {
             assert!($result.is_err(), "{:?}", $result.unwrap());
             if option_env!("PRINTERR").is_some() {
                 crate::init_colour();
-                println!("{:?}", $result.unwrap_err());
+                println!("\n{:?}", $result.unwrap_err());
             }
         };
         ($result:expr, $($arg:tt)+) => {
             assert!($result.is_err(), $($arg)+);
             if option_env!("PRINTERR").is_some() {
                 crate::init_colour();
-                println!("{:?}", $result.unwrap_err());
+                println!("\n{:?}", $result.unwrap_err());
             }
         };
     }
@@ -899,7 +899,6 @@ mod test {
     }
 
     #[test]
-    #[should_panic]
     fn error_in_error_handling() {
         fn output() -> Result<usize, Report<ConversionError>> {
             "NaN"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,6 +490,7 @@ where
 }
 
 pub trait ClearResult<T, E> {
+    #[allow(clippy::result_unit_err)]
     fn clear_err(self) -> Result<T, ()>;
 
     fn clear_ok(self) -> Result<(), E>;


### PR DESCRIPTION
Added `expect_field!` macro:
https://github.com/knox-networks/bigerror/blob/93b087f0ee8447b55ceb67efd980711d0c6cfba6/src/lib.rs#L982-L988
the above `expect_field!` invocation desugars into:
```rust
// ...
let my_field = bigerror::OptionReport::ok_or_not_found_field(my_struct.my_field, "my_field")?;
// ...
```
---
* added `FrError`
* added `SetupError`
* added `just printerr <test::uri>` to show the error trace of a given unit test