### PR TITLE
Introduce typed key/value attachments

### DIFF
--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -100,10 +100,44 @@ pub struct Expectation<E, A> {
     pub actual: A,
 }
 
+#[allow(dead_code)]
+enum Symbol {
+    Vertical,
+    VerticalRight,
+    Horizontal,
+    HorizontalLeft,
+    HorizontalDown,
+    ArrowRight,
+    CurveRight,
+    Space,
+}
+
+impl std::fmt::Display for Symbol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let utf8 = match self {
+            Self::Vertical => "\u{2502}",       // │
+            Self::VerticalRight => "\u{251c}",  // ├
+            Self::Horizontal => "\u{2500}",     // ─
+            Self::HorizontalLeft => "\u{2574}", // ╴
+            Self::HorizontalDown => "\u{252c}", // ┬
+            Self::ArrowRight => "\u{25b6}",     // ▶
+            Self::CurveRight => "\u{2570}",     // ╰
+            Self::Space => " ",
+        };
+        write!(f, "{}", utf8)
+    }
+}
+
 impl<E: Display, A: Display> std::fmt::Display for Expectation<E, A> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "{}", KeyValue("expected", &self.expected))?;
-        writeln!(f, "{}", KeyValue("actual", &self.actual))
+        let cr = Symbol::CurveRight;
+        let hl = Symbol::HorizontalLeft;
+        write!(
+            f,
+            "{}\n{cr}{hl}{}",
+            KeyValue("expected", &self.expected),
+            KeyValue("actual", &self.actual)
+        )
     }
 }
 

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -1,12 +1,12 @@
 use std::time::Duration;
 
-use error_stack::fmt::ColorMode;
+
 use tracing::error;
 
 pub use error_stack::{self, Context, Report, ResultExt};
 pub use thiserror;
 
-use crate::{context, reportable};
+use crate::{reportable};
 
 pub trait Display: std::fmt::Display + std::fmt::Debug + Send + Sync + 'static {}
 

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -1,12 +1,11 @@
 use std::time::Duration;
 
-
 use tracing::error;
 
 pub use error_stack::{self, Context, Report, ResultExt};
 pub use thiserror;
 
-use crate::{reportable};
+use crate::reportable;
 
 pub trait Display: std::fmt::Display + std::fmt::Debug + Send + Sync + 'static {}
 
@@ -36,9 +35,6 @@ pub struct Field<Id, S> {
     id: Id,
     status: S,
 }
-// TODO
-// field!(some_struct.property) -> "some_struct.property"
-// field!(%some_struct.property)
 
 impl<Id: Display, S: Display> std::fmt::Display for Field<Id, S> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,10 +1,11 @@
-use std::path::Path;
-use std::time::Duration;
+use std::{path::Path, time::Duration};
 
 use error_stack::Context;
 
-use crate::attachment::{self, Unsupported};
-use crate::{ty, AttachExt, Report, Reportable};
+use crate::{
+    attachment::{self, Unsupported},
+    ty, AttachExt, Report, Reportable,
+};
 
 use crate::{attachment::DisplayDuration, reportable, Field};
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,15 +1,12 @@
-use crate::{
-    attachment::{self, DisplayDuration, Field, Unsupported},
-    AttachExt, Reportable,
-};
+use std::path::Path;
+use std::time::Duration;
 
-use std::{path::Path, time::Duration};
-use tracing::error;
+use error_stack::Context;
 
-pub use error_stack::{self, Context, Report, ResultExt};
-pub use thiserror;
+use crate::attachment::{self, Unsupported};
+use crate::{ty, AttachExt, Report};
 
-use crate::reportable;
+use crate::{attachment::DisplayDuration, reportable, Field};
 
 #[derive(Debug, thiserror::Error)]
 #[error("{0}")]
@@ -131,25 +128,10 @@ impl InvalidInput {
 
 impl ConversionError {
     #[track_caller]
-    pub fn new<F: ?Sized, T: ?Sized>() -> Report<Self> {
-        let from = std::any::type_name::<F>();
-        let to = std::any::type_name::<T>();
+    pub fn new<F, T>() -> Report<Self> {
         Report::new(Self)
-            .attach_printable(format!("from: {from}"))
-            .attach_printable(format!("to: {to}"))
-    }
-
-    #[track_caller]
-    pub fn from<F, T>(ctx: impl Context) -> Report<Self>
-    where
-        F: ?Sized,
-        T: ?Sized,
-    {
-        let from = std::any::type_name::<F>();
-        let to = std::any::type_name::<T>();
-        Self::report(ctx)
-            .attach_printable(format!("from: {from}"))
-            .attach_printable(format!("to: {to}"))
+            .attach_printable(format!("from: {}", ty!(F)))
+            .attach_printable(format!("to: {}", ty!(T)))
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 use error_stack::Context;
 
 use crate::attachment::{self, Unsupported};
-use crate::{ty, AttachExt, Report};
+use crate::{ty, AttachExt, Report, Reportable};
 
 use crate::{attachment::DisplayDuration, reportable, Field};
 
@@ -130,6 +130,13 @@ impl ConversionError {
     #[track_caller]
     pub fn new<F, T>() -> Report<Self> {
         Report::new(Self)
+            .attach_printable(format!("from: {}", ty!(F)))
+            .attach_printable(format!("to: {}", ty!(T)))
+    }
+
+    #[track_caller]
+    pub fn from<F, T>(ctx: impl Context) -> Report<Self> {
+        Self::report(ctx)
             .attach_printable(format!("from: {}", ty!(F)))
             .attach_printable(format!("to: {}", ty!(T)))
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -947,4 +947,14 @@ mod test {
 
         assert_err!(my_field);
     }
+
+    #[test]
+    fn expectation() {
+        let my_struct = MyStruct { my_field: None };
+        let my_field = my_struct
+            .my_field
+            .ok_or_else(|| InvalidInput::expected_actual("Some", "None"));
+
+        assert_err!(my_field);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -922,7 +922,7 @@ mod test {
         fn output() -> Result<usize, Report<MyError>> {
             "NaN"
                 .parse::<usize>()
-                .map_err(|e| ConversionError::from::<&str, usize>(e))
+                .map_err(ConversionError::from::<&str, usize>)
                 .into_ctx()
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -876,7 +876,7 @@ mod test {
                     Ok(attachment) => e.attach_printable(attachment),
                     Err(attachment_err) => e
                         .attach_printable(ParseError)
-                        .attach_kv("val: \"More Nan\"", attachment_err),
+                        .attach_kv("\"More Nan\"", attachment_err),
                 })
         }
 
@@ -911,7 +911,7 @@ mod test {
         fn output() -> Result<usize, Report<MyError>> {
             "NaN"
                 .parse::<usize>()
-                .map_err(|e| ConversionError::new::<&str, usize>(e).into_ctx())
+                .map_err(|e| ConversionError::from::<&str, usize>(e).into_ctx())
         }
 
         assert_err!(output());
@@ -922,7 +922,7 @@ mod test {
         fn output() -> Result<usize, Report<MyError>> {
             "NaN"
                 .parse::<usize>()
-                .map_err(ConversionError::new::<&str, usize>)
+                .map_err(|e| ConversionError::from::<&str, usize>(e))
                 .into_ctx()
         }
 


### PR DESCRIPTION
* Added `KeyValue` attachment, now used in `Reportable::with_kv` and `AttachExt::attach_kv`:
    https://github.com/knox-networks/bigerror/blob/d27dea90f456d382ef678e866de8af77d9519f9e/src/attachment.rs#L18-L27
* Refactored `Field` attachment:
    https://github.com/knox-networks/bigerror/blob/d27dea90f456d382ef678e866de8af77d9519f9e/src/attachment.rs#L30-L37
* Added `Type` attachment:
    https://github.com/knox-networks/bigerror/blob/d27dea90f456d382ef678e866de8af77d9519f9e/src/attachment.rs#L50-L59

* `*_debug` methods renamed to use the `*_dbg` shorthand