### PR TITLE
Add accessor method handling for `expect_field!`, `ResultIntoContext` trait additions

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,6 @@
+# typos config
+# https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
+[default]
+# mergify regex
+extend-ignore-re = ["~=\\S+"]

--- a/cliff.toml
+++ b/cliff.toml
@@ -37,7 +37,7 @@ filter_unconventional = false
 split_commits = false
 # regex for preprocessing the commit messages
 commit_preprocessors = [
-  { pattern = "\\(#([0-9]+)\\)", replace = "[#${1}](https://github.com/knox-networks/bigerror/pull/${1})"}
+  { pattern = "\\(#([0-9]+)\\)", replace = "[#${1}](https://github.com/knox-networks/bigerror/pull/${1})" },
   # { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](https://github.com/orhun/git-cliff/issues/${2}))"}, # replace issue numbers
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser

--- a/justfile
+++ b/justfile
@@ -8,6 +8,10 @@ fmt:
     rustup run nightly cargo fmt -- \
       --config-path ./fmt/rustfmt.toml
 
+fix *args: && fmt-rs
+  cd {{invocation_directory()}}; cargo clippy --fix --all-targets --all-features {{args}}
+
+
 # Prints the error stack for a given test to stdout
 printerr test $PRINTERR="true":
   @cargo test --quiet --lib -- --exact {{test}} --nocapture

--- a/justfile
+++ b/justfile
@@ -8,6 +8,7 @@ fmt:
     rustup run nightly cargo fmt -- \
       --config-path ./fmt/rustfmt.toml
 
+# Run clippy fix and rustfmt afterwards
 fix *args: && fmt
   cd {{invocation_directory()}}; cargo clippy --fix --all-targets --all-features {{args}}
 

--- a/justfile
+++ b/justfile
@@ -8,7 +8,7 @@ fmt:
     rustup run nightly cargo fmt -- \
       --config-path ./fmt/rustfmt.toml
 
-fix *args: && fmt-rs
+fix *args: && fmt
   cd {{invocation_directory()}}; cargo clippy --fix --all-targets --all-features {{args}}
 
 

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -100,6 +100,9 @@ pub struct Expectation<E, A> {
     pub actual: A,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub struct FromTo<F, T>(pub F, pub T);
+
 #[allow(dead_code)]
 enum Symbol {
     Vertical,
@@ -138,6 +141,15 @@ impl<E: Display, A: Display> std::fmt::Display for Expectation<E, A> {
             KeyValue("expected", &self.expected),
             KeyValue("actual", &self.actual)
         )
+    }
+}
+impl<F: Display, T: Display> std::fmt::Display for FromTo<F, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let cr = Symbol::CurveRight;
+        let hl = Symbol::HorizontalLeft;
+        let from = KeyValue("from", &self.0);
+        let to = KeyValue("to", &self.1);
+        write!(f, "{from}\n{cr}{hl}{to}",)
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -32,7 +32,7 @@ pub struct BoxCoreError(Box<dyn CoreError>);
 pub struct DecodeError;
 reportable!(DecodeError);
 
-/// Represents errors emitted during while turning an object into bytes.
+/// Emitted while turning an object into bytes.
 /// See [`DecodeError`] for more details.
 #[derive(Debug, thiserror::Error)]
 #[error("EncodeError")]
@@ -76,8 +76,8 @@ reportable!(FsError);
 pub struct SetupError;
 reportable!(SetupError);
 
-/// Emitted when casting existing [non scalar](https://en.wikipedia.org/w/index.php?title=Scalar_processor&useskin=vector#Scalar_data_type)
-/// objects (such as structs, enums, and unions) into each other.
+/// Emitted during transformations between [non scalar](https://en.wikipedia.org/w/index.php?title=Scalar_processor&useskin=vector#Scalar_data_type)
+/// objects (such as structs, enums, and unions).
 #[derive(Debug, thiserror::Error)]
 #[error("ConversionError")]
 pub struct ConversionError;

--- a/src/context.rs
+++ b/src/context.rs
@@ -18,12 +18,22 @@ pub struct BoxError(Box<dyn std::error::Error + 'static + Send + Sync>);
 #[derive(Debug, thiserror::Error)]
 #[error("{0}")]
 pub struct BoxCoreError(Box<dyn CoreError>);
-
 #[derive(Debug, thiserror::Error)]
 #[error("DecodeError")]
+/// Represents errors emitted during while processing bytes into an object.
+/// * byte types can can be represented by objects such as `&[u8]`, `bytes::Bytes`, and `Vec<u8>`
+/// * used by codecs/serializers/deserializers
+///   * used by codecs/serializers/deserializers
+///
+///  here's an example of types/traits that can emit encode/decode errors:
+///  * https://docs.rs/tonic/latest/tonic/codec/trait.Encoder.html
+///  * https://docs.rs/rkyv/latest/rkyv/ser/serializers/type.AllocSerializer.html
+///  * https://docs.rs/serde/latest/serde/trait.Serializer.html
 pub struct DecodeError;
 reportable!(DecodeError);
 
+/// Represents errors emitted during while turning an object into bytes.
+/// See [`DecodeError`] for more details.
 #[derive(Debug, thiserror::Error)]
 #[error("EncodeError")]
 pub struct EncodeError;
@@ -39,6 +49,8 @@ reportable!(AuthError);
 pub struct NetworkError;
 reportable!(NetworkError);
 
+/// Emitted while processing a string (UTF-8 or otherwise).
+/// Usually associated with the [`std::str::FromStr`] trait and the `.parse::<SomeT>()` method
 #[derive(Debug, thiserror::Error)]
 #[error("ParseError")]
 pub struct ParseError;
@@ -64,6 +76,8 @@ reportable!(FsError);
 pub struct SetupError;
 reportable!(SetupError);
 
+/// Emitted when casting existing [non scalar](https://en.wikipedia.org/w/index.php?title=Scalar_processor&useskin=vector#Scalar_data_type)
+/// objects (such as structs, enums, and unions) into each other.
 #[derive(Debug, thiserror::Error)]
 #[error("ConversionError")]
 pub struct ConversionError;

--- a/src/context.rs
+++ b/src/context.rs
@@ -39,6 +39,7 @@ reportable!(DecodeError);
 pub struct EncodeError;
 reportable!(EncodeError);
 
+/// Emitted during an authorization/verification check
 #[derive(Debug, thiserror::Error)]
 #[error("AuthError")]
 pub struct AuthError;
@@ -66,11 +67,13 @@ reportable!(NotFound);
 pub struct DbError;
 reportable!(DbError);
 
+/// An error that is related to filesystem operations such as those in [`std::fs`]
 #[derive(Debug, thiserror::Error)]
 #[error("FsError")]
 pub struct FsError;
 reportable!(FsError);
 
+/// Emitted during the startup/provisioning phase of a program
 #[derive(Debug, thiserror::Error)]
 #[error("SetupError")]
 pub struct SetupError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,6 +87,7 @@ pub trait ReportAs<T> {
 }
 
 impl<T, E: Context> ReportAs<T> for Result<T, E> {
+    #[inline]
     #[track_caller]
     fn report_as<C: Reportable>(self) -> Result<T, Report<C>> {
         // TODO #[track_caller] on closure
@@ -100,6 +101,7 @@ impl<T, E: Context> ReportAs<T> for Result<T, E> {
 }
 
 impl<T> ReportAs<T> for &'static str {
+    #[inline]
     #[track_caller]
     fn report_as<C: Reportable>(self) -> Result<T, Report<C>> {
         Err(Report::new(C::value()).attach_printable(self))
@@ -107,6 +109,7 @@ impl<T> ReportAs<T> for &'static str {
 }
 
 impl<T> ReportAs<T> for String {
+    #[inline]
     #[track_caller]
     fn report_as<C: Reportable>(self) -> Result<T, Report<C>> {
         Err(Report::new(C::value()).attach_printable(self))
@@ -127,12 +130,12 @@ impl<C: Context> IntoContext for Report<C> {
 
 pub trait ResultIntoContext: ResultExt {
     fn into_ctx<C2: Reportable>(self) -> Result<Self::Ok, Report<C2>>;
-    // Resut::and_then
-    fn then_ctx<U, F, C2>(self, op: F) -> Result<U, Report<C2>>
+    // Result::and_then
+    fn and_then_ctx<U, F, C2>(self, op: F) -> Result<U, Report<C2>>
     where
         C2: Reportable,
         F: FnOnce(Self::Ok) -> Result<U, Report<C2>>;
-    // Resut::map
+    // Result::map
     fn map_ctx<U, F, C2>(self, op: F) -> Result<U, Report<C2>>
     where
         C2: Reportable,
@@ -151,7 +154,7 @@ where
 
     #[inline]
     #[track_caller]
-    fn then_ctx<U, F, C2>(self, op: F) -> Result<U, Report<C2>>
+    fn and_then_ctx<U, F, C2>(self, op: F) -> Result<U, Report<C2>>
     where
         C2: Reportable,
         F: FnOnce(T) -> Result<U, Report<C2>>,
@@ -255,6 +258,7 @@ pub trait AttachExt {
 }
 
 impl<C> AttachExt for Report<C> {
+    #[inline]
     #[track_caller]
     fn attach_kv<K, V>(self, key: K, value: V) -> Self
     where
@@ -264,6 +268,7 @@ impl<C> AttachExt for Report<C> {
         self.attach_printable(KeyValue(key, value))
     }
 
+    #[inline]
     #[track_caller]
     fn attach_kv_dbg<K, V>(self, key: K, value: V) -> Self
     where
@@ -282,6 +287,7 @@ impl<C> AttachExt for Report<C> {
         self.attach_printable(Field::new(name, status))
     }
 
+    #[inline]
     #[track_caller]
     fn attach_dbg<A>(self, value: A) -> Self
     where
@@ -292,6 +298,7 @@ impl<C> AttachExt for Report<C> {
 }
 
 impl<T, C> AttachExt for Result<T, Report<C>> {
+    #[inline]
     #[track_caller]
     fn attach_kv<K, V>(self, key: K, value: V) -> Self
     where
@@ -1002,7 +1009,7 @@ mod test {
         assert_err!(my_field);
     }
 
-    // this is meant to be a complie time test of the `__field!` macro
+    // this is meant to be a compile time test of the `__field!` macro
     fn __field() {
         let my_struct = MyStruct::default();
         __field!(MyStruct::__field::<&str> | &my_struct._string);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -772,14 +772,6 @@ impl<T> OptionReport for Option<T> {
 }
 
 #[macro_export]
-macro_rules! __strip {
-    // much TTs
-    (@[$($pre:ident)+], $field:ident . $($rest:tt)+) => {
-        $crate::__field!(@[$($pre)+ $field], $($rest)+)
-    };
-}
-
-#[macro_export]
 macro_rules! __field {
     // === exits ===
     // handle optional method calls: self.x.as_ref()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,7 +62,7 @@ where
 
     #[track_caller]
     fn with_variant<A: Display>(value: A) -> Report<Self> {
-        Self::with_kv_dbg(attachment::Type::of::<A>(), value)
+        Self::with_kv(attachment::Type::of::<A>(), value)
     }
 
     #[track_caller]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub trait ResultIntoContext: ResultExt {
     fn map_ctx<U, F, C2>(self, op: F) -> Result<U, Report<C2>>
     where
         C2: Reportable,
-        F: FnOnce(Self::Ok) -> Result<U, Self::Context>;
+        F: FnOnce(Self::Ok) -> Result<U, Report<C2>>;
 }
 
 impl<T, C> ResultIntoContext for Result<T, Report<C>>
@@ -149,10 +149,10 @@ where
     fn map_ctx<U, F, C2>(self, op: F) -> Result<U, Report<C2>>
     where
         C2: Reportable,
-        F: FnOnce(<Self as ResultExt>::Ok) -> Result<U, C>,
+        F: FnOnce(T) -> Result<U, Report<C2>>,
     {
         match self {
-            Ok(t) => op(t).change_context(C2::value()),
+            Ok(t) => op(t),
             Err(ctx) => Err(ctx.into_ctx()),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1005,7 +1005,7 @@ mod test {
     // this is meant to be a complie time test of the `__field!` macro
     fn __field() {
         let my_struct = MyStruct::default();
-        let _out: () = __field!(MyStruct::__field::<&str> | &my_struct._string);
+        __field!(MyStruct::__field::<&str> | &my_struct._string);
     }
 
     #[test]


### PR DESCRIPTION
`ResultIntoContext` trait:
* added `ResultIntoContext::then_ctx` and `ResultIntoContext::map_ctx`, equivalent to `Result::and_then` and `Result::map` for results where the error is `Report<impl Reportable>`
https://github.com/knox-networks/bigerror/blob/19b176fc03490f80621e6d56de0cb4982d9b5078/src/lib.rs#L128-L138
---
`expect_field!` macro:
-  accessor methods can now be treated as fields by prepending the method name with `%`:
  https://github.com/knox-networks/bigerror/blob/6892246c8cfa4c6e5247daeba55f10de5635b7cd/src/lib.rs#L986
  The above codeblock expands to:
    ```rust
    bigerror::OptionReport::expect_field(my_struct.my_field(), "my_field")
    ```
---
Added new contexts:
* `EncodeError`
* `DecodeError`
* `AuthError`
* `InvalidState`
---
Added `attachment::FromTo`

