### PR TITLE
Added `kv!` macro to provide a `KeyValue` shorthand

### DIFF
--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ fix *args: && fmt
 
 # Prints the error stack for a given test to stdout
 printerr test $PRINTERR="true":
-  @cargo test --quiet --lib -- --exact {{test}} --nocapture
+  @cargo test --quiet --lib -- --exact test::{{test}} --nocapture
 
-printerr-all $PRINTERR="true":
-  @cargo test --quiet --lib -- --exact --nocapture
+printerr-all $PRINTERR="true" $RUST_TEST_THREADS="1":
+  @cargo test --lib -- --exact --nocapture

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -30,9 +30,6 @@ impl KeyValue<String, String> {
 /// `ty:` prefix using the `$value` [`Type`] as the key
 #[macro_export]
 macro_rules! kv {
-    (ty: $value: literal) => {
-        $crate::KeyValue($crate::Type::of_val(&$value), $value)
-    };
     (ty: $value: expr) => {
         $crate::KeyValue($crate::Type::of_val(&$value), $value)
     };
@@ -229,12 +226,17 @@ mod test {
     #[test]
     fn kv_macro() {
         let foo = "Foo";
+
+        // foo: "Foo"
         assert_eq!(kv!(foo), KeyValue("foo", "Foo"));
         // <&str>: "Foo"
         assert_eq!(kv!(ty: foo), KeyValue(Type::of_val(&foo), "Foo"));
 
         let foo = 13;
+
         // <i32>: 13
         assert_eq!(kv!(ty: foo), KeyValue(Type::of_val(&foo), 13));
+        // ensure literal values are handled correctly
+        assert_eq!(kv!(ty: 13), KeyValue(Type::of_val(&13), 13));
     }
 }

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -26,6 +26,8 @@ impl KeyValue<String, String> {
     }
 }
 
+/// Allows one to quickly specify a [`KeyValue`] pair, optionally using a
+/// `ty:` prefix using the `$value` [`Type`] as the key
 #[macro_export]
 macro_rules! kv {
     (ty: $value: literal) => {

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -16,7 +16,7 @@ pub trait Debug: std::fmt::Debug + Send + Sync + 'static {}
 impl<A> Debug for A where A: std::fmt::Debug + Send + Sync + 'static {}
 
 // simple key-value pair attachment
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, PartialEq, thiserror::Error)]
 #[error("{0}: {1}")]
 pub struct KeyValue<K, V>(pub K, pub V);
 
@@ -24,6 +24,19 @@ impl KeyValue<String, String> {
     pub fn dbg(key: impl Debug, value: impl Debug) -> Self {
         Self(format!("{key:?}"), format!("{value:?}"))
     }
+}
+
+#[macro_export]
+macro_rules! kv {
+    (ty: $value: literal) => {
+        $crate::KeyValue($crate::Type::of_val(&$value), $value)
+    };
+    (ty: $value: expr) => {
+        $crate::KeyValue($crate::Type::of_val(&$value), $value)
+    };
+    ($value: expr) => {
+        $crate::KeyValue(stringify!($value), $value)
+    };
 }
 
 #[derive(Debug)]
@@ -49,11 +62,16 @@ impl<Id: Display, S: Display> Field<Id, S> {
 }
 /// wrapper attachment that is used to refer to the type of an object
 /// rather than the value
+#[derive(PartialEq)]
 pub struct Type(&'static str);
 
 impl Type {
     // const fn when type_name is const fn in stable
     pub fn of<T>() -> Self {
+        Self(std::any::type_name::<T>())
+    }
+
+    pub fn of_val<T: ?Sized>(_val: &T) -> Self {
         Self(std::any::type_name::<T>())
     }
 }
@@ -201,3 +219,20 @@ pub fn hms_string(duration: Duration) -> String {
 #[derive(Debug, thiserror::Error)]
 #[error("Index[{0}]")]
 pub struct Index<I: std::fmt::Display>(pub I);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn kv_macro() {
+        let foo = "Foo";
+        assert_eq!(kv!(foo), KeyValue("foo", "Foo"));
+        // <&str>: "Foo"
+        assert_eq!(kv!(ty: foo), KeyValue(Type::of_val(&foo), "Foo"));
+
+        let foo = 13;
+        // <i32>: 13
+        assert_eq!(kv!(ty: foo), KeyValue(Type::of_val(&foo), 13));
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -9,12 +9,13 @@ use crate::{
 
 use crate::{attachment::DisplayDuration, reportable, Field};
 
+/// Used to enacpsulate opaque `dyn std::error::Error` types
 #[derive(Debug, thiserror::Error)]
 #[error("{0}")]
 pub struct BoxError(Box<dyn std::error::Error + 'static + Send + Sync>);
 
-// this is a `BoxError` that satistifes `core::error::Error`
-// using `core::fmt::Debug` and `core::fmt::Display`
+/// this is a [`BoxError`] that satistifes [`core::error::Error`]
+/// using [`core::fmt::Debug`] and [`core::fmt::Display`]
 #[derive(Debug, thiserror::Error)]
 #[error("{0}")]
 pub struct BoxCoreError(Box<dyn CoreError>);
@@ -57,6 +58,7 @@ reportable!(NetworkError);
 pub struct ParseError;
 reportable!(ParseError);
 
+/// Represents the conversion of an `Option::<T>::None` into a [`Report`]
 #[derive(Debug, thiserror::Error)]
 #[error("NotFound")]
 pub struct NotFound;
@@ -101,11 +103,13 @@ reportable!(InvalidStatus);
 pub struct InvalidState;
 reportable!(InvalidState);
 
+/// Emitted during runtime, indicates problems with input/default settings
 #[derive(Debug, thiserror::Error)]
 #[error("ConfigError")]
 pub struct ConfigError;
 reportable!(ConfigError);
 
+/// Typically emitted by a `build.rs` failure
 #[derive(Debug, thiserror::Error)]
 #[error("BuildError")]
 pub struct BuildError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1067,7 +1067,7 @@ mod test {
         assert_err!(compare(my_number, other_number));
     }
 
-    // should behave the same as attach_variant
+    // should behave the same as `test::attach_variant`
     // but displays lazy allocation of attachment
     #[test]
     fn attach_kv_macro() {
@@ -1076,7 +1076,7 @@ mod test {
         fn compare(mine: usize, other: usize) -> Result<(), Report<MyError>> {
             if other != mine {
                 return Err(InvalidInput::attach("expected my number!"))
-                    .attach_printable_lazy(|| kv!(ty: other))
+                    .attach_printable_lazy(|| kv!(ty: other)) // <usize>: 3
                     .into_ctx();
             }
             Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,9 @@ pub mod context;
 #[cfg(feature = "grpc")]
 pub mod grpc;
 
-pub use attachment::Field;
+pub use attachment::{Expectation, Field, Index, KeyValue, Type};
 
-use attachment::{Debug, Display, Expectation, Index, KeyValue};
+use attachment::{Debug, Display};
 pub use context::*;
 
 // TODO we'll have to do a builder pattern here at
@@ -1061,6 +1061,23 @@ mod test {
                 bail!(InvalidInput::attach("expected my number!")
                     .attach_variant(other)
                     .into_ctx());
+            }
+            Ok(())
+        }
+        assert_err!(compare(my_number, other_number));
+    }
+
+    // should behave the same as attach_variant
+    // but displays lazy allocation of attachment
+    #[test]
+    fn attach_kv_macro() {
+        let my_number = 2;
+        let other_number = 3;
+        fn compare(mine: usize, other: usize) -> Result<(), Report<MyError>> {
+            if other != mine {
+                return Err(InvalidInput::attach("expected my number!"))
+                    .attach_printable_lazy(|| kv!(ty: other))
+                    .into_ctx();
             }
             Ok(())
         }


### PR DESCRIPTION
Added a `kv!` macro to allow a flexible way to define `KeyValue` attachments:
https://github.com/knox-networks/bigerror/blob/e5402869404d409155206a14932aa068354e275e/src/attachment.rs#L228-L240

`just printerr attach_variant` can be run to show the output of the combination of `kv!(ty: other)` with `.attach_printable_lazy( ... )`