### PR TITLE
Added `attachment::Dbg`

### DIFF
--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -237,10 +237,10 @@ pub fn hms_string(duration: Duration) -> String {
 
 // this is meant to explicitly indicate
 // that the underlying `A` is being
-// used as an index key for getter methods
+// used as an index key for getter methods in a collection
 // such as `HashMap` keys and `Vec` indices
 #[derive(Debug, thiserror::Error)]
-#[error("Index[{0}]")]
+#[error("idx [{0}: {}]", std::any::type_name::<I>())]
 pub struct Index<I: std::fmt::Display>(pub I);
 
 #[cfg(test)]

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -29,7 +29,7 @@ impl<A: Debug> std::fmt::Display for Dbg<A> {
 #[derive(Debug, PartialEq)]
 pub struct KeyValue<K, V>(pub K, pub V);
 
-impl<K: Display, V: Display> std::fmt::Display for KeyValue<K, V> {
+impl<K: std::fmt::Display, V: std::fmt::Display> std::fmt::Display for KeyValue<K, V> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}: {}", self.0, self.1)
     }
@@ -165,20 +165,24 @@ impl std::fmt::Display for Symbol {
 
 impl<E: Display, A: Display> std::fmt::Display for Expectation<E, A> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let cr = Symbol::CurveRight;
-        let hl = Symbol::HorizontalLeft;
-        let expected = KeyValue("expected", self.expected.to_string());
-        let actual = KeyValue("actual", self.actual.to_string());
-        write!(f, "{expected}\n{cr}{hl}{actual}")
+        let curve_right = Symbol::CurveRight;
+        let horizontal_left = Symbol::HorizontalLeft;
+        let expected = KeyValue("expected", &self.expected);
+        let actual = KeyValue("actual", &self.actual);
+        // "expected": expected
+        // ╰╴"actual": actual
+        write!(f, "{expected}\n{curve_right}{horizontal_left}{actual}")
     }
 }
 impl<F: Display, T: Display> std::fmt::Display for FromTo<F, T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let cr = Symbol::CurveRight;
-        let hl = Symbol::HorizontalLeft;
-        let from = KeyValue("from", self.0.to_string());
-        let to = KeyValue("to", self.1.to_string());
-        write!(f, "{from}\n{cr}{hl}{to}",)
+        let curve_right = Symbol::CurveRight;
+        let horizontal_left = Symbol::HorizontalLeft;
+        let from = KeyValue("from", &self.0);
+        let to = KeyValue("to", &self.1);
+        // "from": from
+        // ╰╴"to": to
+        write!(f, "{from}\n{curve_right}{horizontal_left}{to}")
     }
 }
 

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{any, fmt, time::Duration};
 
 use tracing::error;
 
@@ -7,20 +7,20 @@ pub use thiserror;
 
 use crate::reportable;
 
-pub trait Display: std::fmt::Display + std::fmt::Debug + Send + Sync + 'static {}
+pub trait Display: fmt::Display + fmt::Debug + Send + Sync + 'static {}
 
-impl<A> Display for A where A: std::fmt::Display + std::fmt::Debug + Send + Sync + 'static {}
+impl<A> Display for A where A: fmt::Display + fmt::Debug + Send + Sync + 'static {}
 
-pub trait Debug: std::fmt::Debug + Send + Sync + 'static {}
+pub trait Debug: fmt::Debug + Send + Sync + 'static {}
 
-impl<A> Debug for A where A: std::fmt::Debug + Send + Sync + 'static {}
+impl<A> Debug for A where A: fmt::Debug + Send + Sync + 'static {}
 
 // used to wrap types that only implement `std::fmt::Debug`
 #[derive(Debug)]
 pub struct Dbg<A: Debug>(pub A);
 
-impl<A: Debug> std::fmt::Display for Dbg<A> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<A: Debug> fmt::Display for Dbg<A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self.0)
     }
 }
@@ -29,8 +29,8 @@ impl<A: Debug> std::fmt::Display for Dbg<A> {
 #[derive(Debug, PartialEq)]
 pub struct KeyValue<K, V>(pub K, pub V);
 
-impl<K: std::fmt::Display, V: std::fmt::Display> std::fmt::Display for KeyValue<K, V> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<K: fmt::Display, V: fmt::Display> fmt::Display for KeyValue<K, V> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}: {}", self.0, self.1)
     }
 }
@@ -63,8 +63,8 @@ pub struct Field<Id, S> {
     status: S,
 }
 
-impl<Id: Display, S: Display> std::fmt::Display for Field<Id, S> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<Id: Display, S: Display> fmt::Display for Field<Id, S> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}: {}", self.id, self.status)
     }
 }
@@ -82,22 +82,22 @@ pub struct Type(&'static str);
 impl Type {
     // const fn when type_name is const fn in stable
     pub fn of<T>() -> Self {
-        Self(std::any::type_name::<T>())
+        Self(any::type_name::<T>())
     }
 
     pub fn of_val<T: ?Sized>(_val: &T) -> Self {
-        Self(std::any::type_name::<T>())
+        Self(any::type_name::<T>())
     }
 }
 
-impl std::fmt::Display for Type {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Type {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "<{}>", self.0)
     }
 }
 
-impl std::fmt::Debug for Type {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for Type {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("Type").field(&self.0).finish()
     }
 }
@@ -147,8 +147,8 @@ enum Symbol {
     Space,
 }
 
-impl std::fmt::Display for Symbol {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Symbol {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let utf8 = match self {
             Self::Vertical => "\u{2502}",       // │
             Self::VerticalRight => "\u{251c}",  // ├
@@ -163,8 +163,8 @@ impl std::fmt::Display for Symbol {
     }
 }
 
-impl<E: Display, A: Display> std::fmt::Display for Expectation<E, A> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<E: Display, A: Display> fmt::Display for Expectation<E, A> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let curve_right = Symbol::CurveRight;
         let horizontal_left = Symbol::HorizontalLeft;
         let expected = KeyValue("expected", &self.expected);
@@ -174,8 +174,8 @@ impl<E: Display, A: Display> std::fmt::Display for Expectation<E, A> {
         write!(f, "{expected}\n{curve_right}{horizontal_left}{actual}")
     }
 }
-impl<F: Display, T: Display> std::fmt::Display for FromTo<F, T> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl<F: Display, T: Display> fmt::Display for FromTo<F, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let curve_right = Symbol::CurveRight;
         let horizontal_left = Symbol::HorizontalLeft;
         let from = KeyValue("from", &self.0);
@@ -188,8 +188,8 @@ impl<F: Display, T: Display> std::fmt::Display for FromTo<F, T> {
 
 #[derive(Debug)]
 pub struct DisplayDuration(pub Duration);
-impl std::fmt::Display for DisplayDuration {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for DisplayDuration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", hms_string(self.0))
     }
 }
@@ -241,7 +241,7 @@ pub fn hms_string(duration: Duration) -> String {
 // such as `HashMap` keys and `Vec` indices
 #[derive(Debug, thiserror::Error)]
 #[error("idx [{0}: {}]", std::any::type_name::<I>())]
-pub struct Index<I: std::fmt::Display>(pub I);
+pub struct Index<I: fmt::Display>(pub I);
 
 #[cfg(test)]
 mod test {

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -159,7 +159,7 @@ impl fmt::Display for Symbol {
             Self::CurveRight => "\u{2570}",     // ╰
             Self::Space => " ",
         };
-        write!(f, "{}", utf8)
+        write!(f, "{utf8}")
     }
 }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,4 +1,4 @@
-use std::{path::Path, time::Duration};
+use std::{any, path::Path, time::Duration};
 
 use error_stack::Context;
 
@@ -163,7 +163,7 @@ impl InvalidInput {
 
     #[track_caller]
     pub fn type_name<T: ?Sized>() -> Report<Self> {
-        let type_name = std::any::type_name::<T>();
+        let type_name = any::type_name::<T>();
         Report::new(Self).attach_printable(format!("type: {type_name}"))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ pub mod grpc;
 
 pub use attachment::{Expectation, Field, Index, KeyValue, Type};
 
-use attachment::{Debug, Display};
+use attachment::{Dbg, Debug, Display};
 pub use context::*;
 
 // TODO we'll have to do a builder pattern here at
@@ -35,27 +35,47 @@ pub trait Reportable
 where
     Self: Sized + Context,
 {
-    fn report<C: Context>(ctx: C) -> Report<Self>;
+    fn value() -> Self;
+    fn report<C: Context>(ctx: C) -> Report<Self> {
+        Report::new(ctx).change_context(Self::value())
+    }
     // TODO
     // fn report_dyn_err(err: impl std::error::Error + 'static + Send + Sync)
     // -> Report<Self>;
+    #[track_caller]
     fn attach<A>(value: A) -> Report<Self>
     where
-        A: Display;
+        A: Display,
+    {
+        Report::new(Self::value()).attach_printable(value)
+    }
+    #[track_caller]
     fn attach_dbg<A>(value: A) -> Report<Self>
     where
-        A: Debug;
+        A: Debug,
+    {
+        Self::attach(Dbg(value))
+    }
+    #[track_caller]
     fn with_kv<K, V>(key: K, value: V) -> Report<Self>
     where
         K: Display,
-        V: Display;
+        V: Display,
+    {
+        Self::attach(KeyValue(key, value))
+    }
+    #[track_caller]
     fn with_kv_dbg<K, V>(key: K, value: V) -> Report<Self>
     where
-        K: Debug,
-        V: Debug;
-    fn with_field_status<S: Display>(key: &'static str, status: S) -> Report<Self>;
-
-    fn value() -> Self;
+        K: Display,
+        V: Debug,
+    {
+        Self::attach(KeyValue::dbg(key, value))
+    }
+    #[track_caller]
+    fn with_field_status<S: Display>(key: &'static str, status: S) -> Report<Self> {
+        Self::attach(Field::new(key, status))
+    }
 
     #[track_caller]
     fn expected_actual<A: attachment::Display>(expected: A, actual: A) -> Report<Self> {
@@ -99,22 +119,6 @@ impl<T, E: Context> ReportAs<T> for Result<T, E> {
             Ok(v) => Ok(v),
             Err(e) => Err(Report::new(C::value()).attach_printable(e)),
         }
-    }
-}
-
-impl<T> ReportAs<T> for &'static str {
-    #[inline]
-    #[track_caller]
-    fn report_as<C: Reportable>(self) -> Result<T, Report<C>> {
-        Err(Report::new(C::value()).attach_printable(self))
-    }
-}
-
-impl<T> ReportAs<T> for String {
-    #[inline]
-    #[track_caller]
-    fn report_as<C: Reportable>(self) -> Result<T, Report<C>> {
-        Err(Report::new(C::value()).attach_printable(self))
     }
 }
 
@@ -191,49 +195,6 @@ macro_rules! reportable {
                 $crate::Report::new(ctx).change_context(Self)
             }
 
-            #[track_caller]
-            fn attach<A>(value: A) -> $crate::Report<Self>
-            where
-                A: $crate::attachment::Display,
-            {
-                $crate::Report::new(Self).attach_printable(value)
-            }
-
-            #[track_caller]
-            fn attach_dbg<A>(value: A) -> $crate::Report<Self>
-            where
-                A: $crate::attachment::Debug,
-            {
-                $crate::Report::new(Self).attach_printable(format!("{value:?}"))
-            }
-
-            #[track_caller]
-            fn with_kv<K, V>(key: K, value: V) -> $crate::Report<Self>
-            where
-                K: $crate::attachment::Display,
-                V: $crate::attachment::Display,
-            {
-                use $crate::AttachExt;
-                $crate::Report::new(Self).attach_kv(key, value)
-            }
-            #[track_caller]
-            fn with_kv_dbg<K, V>(key: K, value: V) -> $crate::Report<Self>
-            where
-                K: $crate::attachment::Debug,
-                V: $crate::attachment::Debug,
-            {
-                use $crate::AttachExt;
-                $crate::Report::new(Self).attach_kv_dbg(key, value)
-            }
-            #[track_caller]
-            fn with_field_status<S>(key: &'static str, status: S) -> $crate::Report<Self>
-            where
-                S: $crate::attachment::Display,
-            {
-                $crate::Report::new(Self)
-                    .attach_printable($crate::attachment::Field::new(key, status))
-            }
-
             fn value() -> Self {
                 $context
             }
@@ -248,7 +209,7 @@ pub trait AttachExt {
         V: Display;
     fn attach_kv_dbg<K, V>(self, key: K, value: V) -> Self
     where
-        K: Debug,
+        K: Display,
         V: Debug;
 
     fn attach_field_status<S>(self, name: &'static str, status: S) -> Self
@@ -281,7 +242,7 @@ impl<C> AttachExt for Report<C> {
     #[track_caller]
     fn attach_kv_dbg<K, V>(self, key: K, value: V) -> Self
     where
-        K: Debug,
+        K: Display,
         V: Debug,
     {
         self.attach_printable(KeyValue::dbg(key, value))
@@ -302,7 +263,7 @@ impl<C> AttachExt for Report<C> {
     where
         A: Debug,
     {
-        self.attach_printable(format!("{value:?}"))
+        self.attach_printable(Dbg(value))
     }
 }
 
@@ -324,7 +285,7 @@ impl<T, C> AttachExt for Result<T, Report<C>> {
     #[track_caller]
     fn attach_kv_dbg<K, V>(self, key: K, value: V) -> Self
     where
-        K: Debug,
+        K: Display,
         V: Debug,
     {
         match self {
@@ -353,82 +314,7 @@ impl<T, C> AttachExt for Result<T, Report<C>> {
     {
         match self {
             Ok(ok) => Ok(ok),
-            Err(report) => Err(report.attach_printable(format!("{value:?}"))),
-        }
-    }
-}
-
-pub trait ResultAttachExt: ResultExt {
-    fn attach_kv<K, V>(self, key: K, value: V) -> Result<Self::Ok, Report<Self::Context>>
-    where
-        K: Display,
-        V: Display;
-    fn attach_kv_dbg<K, V>(self, key: K, value: V) -> Result<Self::Ok, Report<Self::Context>>
-    where
-        K: Debug,
-        V: Debug;
-
-    fn attach_field_status<S>(
-        self,
-        name: &'static str,
-        status: S,
-    ) -> Result<Self::Ok, Report<Self::Context>>
-    where
-        S: Display;
-    fn attach_dbg<A>(self, value: A) -> Result<Self::Ok, Report<Self::Context>>
-    where
-        A: Debug;
-}
-
-impl<T, C> ResultAttachExt for Result<T, C>
-where
-    C: Context,
-{
-    #[inline]
-    #[track_caller]
-    fn attach_kv<K, V>(self, key: K, value: V) -> Result<T, Report<C>>
-    where
-        K: Display,
-        V: Display,
-    {
-        match self {
-            Ok(ok) => Ok(ok),
-            Err(e) => Err(Report::from(e).attach_printable(KeyValue(key, value))),
-        }
-    }
-    #[inline]
-    #[track_caller]
-    fn attach_kv_dbg<K, V>(self, key: K, value: V) -> Result<T, Report<C>>
-    where
-        K: Debug,
-        V: Debug,
-    {
-        match self {
-            Ok(ok) => Ok(ok),
-            Err(e) => Err(Report::from(e).attach_printable(KeyValue::dbg(key, value))),
-        }
-    }
-
-    #[inline]
-    #[track_caller]
-    fn attach_field_status<S>(self, name: &'static str, status: S) -> Result<T, Report<C>>
-    where
-        S: Display,
-    {
-        match self {
-            Ok(ok) => Ok(ok),
-            Err(e) => Err(Report::from(e).attach_printable(Field::new(name, status))),
-        }
-    }
-    #[inline]
-    #[track_caller]
-    fn attach_dbg<A>(self, value: A) -> Result<T, Report<C>>
-    where
-        A: Debug,
-    {
-        match self {
-            Ok(ok) => Ok(ok),
-            Err(e) => Err(Report::from(e).attach_printable(format!("{value:?}"))),
+            Err(report) => Err(report.attach_printable(Dbg(value))),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,7 +365,7 @@ where
     }
     #[inline]
     #[track_caller]
-    fn and_log(self, level: Level) -> Result<T, E> {
+    fn and_log(self, level: Level) -> Self {
         if let Err(err) = &self {
             match level {
                 Level::TRACE => trace!(?err),
@@ -380,7 +380,7 @@ where
 
     #[inline]
     #[track_caller]
-    fn and_log_err(self) -> Result<T, E> {
+    fn and_log_err(self) -> Self {
         if let Err(e) = &self {
             error!(message = ?e);
         }
@@ -389,7 +389,7 @@ where
 
     #[inline]
     #[track_caller]
-    fn and_attached_err<A>(self, attachment: A) -> Result<T, E>
+    fn and_attached_err<A>(self, attachment: A) -> Self
     where
         A: fmt::Debug + Send + Sync + 'static,
     {
@@ -401,7 +401,7 @@ where
 
     #[inline]
     #[track_caller]
-    fn on_err(self, op: impl FnOnce()) -> Result<T, E> {
+    fn on_err(self, op: impl FnOnce()) -> Self {
         op();
         self
     }
@@ -444,7 +444,7 @@ pub trait FromReport<C> {
 /// USAGE:
 /// * `impl From<SomeError as ToReport<_> $(as $context:path)*> for OurError::Report(OurReportError)`
 ///  - Implements `From<E> where E: ToReport<_>` for  errors that implement [`ToReport`]
-/// * impl From<Report<SomeError>>> for OurError::Report(TransactionError)
+/// * impl From<Report<SomeError>>> for `OurError::Report(TransactionError`)
 ///  - Implements `From<Report<SomeError>>` for `Report<OurReportError>`
 /// * `impl From<SomeError $(as $context:path)*> for OurError::Report(TransactionError)`
 ///  - Implements `From<SomeError>` for `Report<OurReportError>`
@@ -633,7 +633,7 @@ where
 }
 
 impl<C> ToReport<C> for Report<C> {
-    fn to_report(self) -> Report<C> {
+    fn to_report(self) -> Self {
         self
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -444,7 +444,7 @@ pub trait FromReport<C> {
 /// USAGE:
 /// * `impl From<SomeError as ToReport<_> $(as $context:path)*> for OurError::Report(OurReportError)`
 ///  - Implements `From<E> where E: ToReport<_>` for  errors that implement [`ToReport`]
-/// * impl From<Report<SomeError>>> for `OurError::Report(TransactionError`)
+/// * `impl From<Report<SomeError>>> for OurError::Report(TransactionError)`
 ///  - Implements `From<Report<SomeError>>` for `Report<OurReportError>`
 /// * `impl From<SomeError $(as $context:path)*> for OurError::Report(TransactionError)`
 ///  - Implements `From<SomeError>` for `Report<OurReportError>`


### PR DESCRIPTION
Introduced `attachment::Dbg` to avoid prematurely allocating `String`s through early `format!` calls.

* Moved most `Reportable` method implementations out of `reportable!` and into blanket implementations under the trait proper.
* Removed `ResultAttachExt`