### PR TITLE
Added `OptionReport::expect_by_fn`

### DIFF
--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -81,6 +81,7 @@ pub struct Type(&'static str);
 
 impl Type {
     // const fn when type_name is const fn in stable
+    #[must_use]
     pub fn of<T>() -> Self {
         Self(simple_type_name::<T>())
     }
@@ -209,6 +210,7 @@ impl std::ops::Deref for DisplayDuration {
 }
 
 /// convert a [`Duration`] into a "0H00m00s" string
+#[must_use]
 pub fn hms_string(duration: Duration) -> String {
     if duration.is_zero() {
         return "ZERO".to_string();
@@ -237,10 +239,7 @@ pub fn hms_string(duration: Duration) -> String {
 
 pub(crate) fn simple_type_name<T: ?Sized>() -> &'static str {
     let full_type = std::any::type_name::<T>();
-    full_type
-        .rsplit_once("::")
-        .map(|t| t.1)
-        .unwrap_or(full_type)
+    full_type.rsplit_once("::").map_or(full_type, |t| t.1)
 }
 
 // this is meant to explicitly indicate

--- a/src/attachment.rs
+++ b/src/attachment.rs
@@ -1,4 +1,4 @@
-use std::{any, fmt, time::Duration};
+use std::{fmt, time::Duration};
 
 use tracing::error;
 
@@ -82,11 +82,11 @@ pub struct Type(&'static str);
 impl Type {
     // const fn when type_name is const fn in stable
     pub fn of<T>() -> Self {
-        Self(any::type_name::<T>())
+        Self(simple_type_name::<T>())
     }
 
     pub fn of_val<T: ?Sized>(_val: &T) -> Self {
-        Self(any::type_name::<T>())
+        Self(simple_type_name::<T>())
     }
 }
 
@@ -235,12 +235,20 @@ pub fn hms_string(duration: Duration) -> String {
     hms
 }
 
+pub(crate) fn simple_type_name<T: ?Sized>() -> &'static str {
+    let full_type = std::any::type_name::<T>();
+    full_type
+        .rsplit_once("::")
+        .map(|t| t.1)
+        .unwrap_or(full_type)
+}
+
 // this is meant to explicitly indicate
 // that the underlying `A` is being
 // used as an index key for getter methods in a collection
 // such as `HashMap` keys and `Vec` indices
 #[derive(Debug, thiserror::Error)]
-#[error("idx [{0}: {}]", std::any::type_name::<I>())]
+#[error("idx [{0}: {}]", simple_type_name::<I>())]
 pub struct Index<I: fmt::Display>(pub I);
 
 #[cfg(test)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,9 +1,9 @@
-use std::{any, path::Path, time::Duration};
+use std::{path::Path, time::Duration};
 
 use error_stack::Context;
 
 use crate::{
-    attachment::{self, FromTo, Unsupported},
+    attachment::{self, simple_type_name, FromTo, Unsupported},
     ty, AttachExt, Report, Reportable,
 };
 
@@ -163,7 +163,7 @@ impl InvalidInput {
 
     #[track_caller]
     pub fn type_name<T: ?Sized>() -> Report<Self> {
-        let type_name = any::type_name::<T>();
+        let type_name = simple_type_name::<T>();
         Report::new(Self).attach_printable(format!("type: {type_name}"))
     }
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -27,9 +27,9 @@ pub struct BoxCoreError(Box<dyn CoreError>);
 ///   * used by codecs/serializers/deserializers
 ///
 ///  here's an example of types/traits that can emit encode/decode errors:
-///  * https://docs.rs/tonic/latest/tonic/codec/trait.Encoder.html
-///  * https://docs.rs/rkyv/latest/rkyv/ser/serializers/type.AllocSerializer.html
-///  * https://docs.rs/serde/latest/serde/trait.Serializer.html
+///  * <https://docs.rs/tonic/latest/tonic/codec/trait.Encoder.html>
+///  * <https://docs.rs/rkyv/latest/rkyv/ser/serializers/type.AllocSerializer.html>
+///  * <https://docs.rs/serde/latest/serde/trait.Serializer.html>
 pub struct DecodeError;
 reportable!(DecodeError);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -682,6 +682,16 @@ where
     fn expect_by<K: Display>(self, key: K) -> Result<T, Report<NotFound>> {
         self.expect_kv(Index(key), ty!(T))
     }
+
+    #[inline]
+    #[track_caller]
+    fn expect_by_fn<F, K>(self, key_fn: F) -> Result<T, Report<NotFound>>
+    where
+        K: Display,
+        F: FnOnce() -> K,
+    {
+        self.expect_kv(Index(key_fn()), ty!(T))
+    }
 }
 
 impl<T> OptionReport<T> for Option<T> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,9 +37,15 @@ where
     fn report<C: Context>(ctx: C) -> Report<Self> {
         Report::new(ctx).change_context(Self::value())
     }
-    // TODO
-    // fn report_dyn_err(err: impl std::error::Error + 'static + Send + Sync)
-    // -> Report<Self>;
+
+    #[track_caller]
+    fn attach_fn<A>(attach_fn: impl FnOnce() -> A) -> Report<Self>
+    where
+        A: Display,
+    {
+        Report::new(Self::value()).attach_printable(attach_fn())
+    }
+
     #[track_caller]
     fn attach<A>(value: A) -> Report<Self>
     where
@@ -980,8 +986,6 @@ mod test {
 
     #[test]
     fn attach_variant() {
-        let my_number = 2;
-        let other_number = 3;
         fn compare(mine: usize, other: usize) -> Result<(), Report<MyError>> {
             if other != mine {
                 bail!(InvalidInput::attach("expected my number!")
@@ -990,6 +994,10 @@ mod test {
             }
             Ok(())
         }
+
+        let my_number = 2;
+        let other_number = 3;
+
         assert_err!(compare(my_number, other_number));
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -893,7 +893,7 @@ mod test {
     fn option_report() {
         assert_err!(None::<()>.expect_or());
 
-        let id: u32 = 0xdeadbeef;
+        let id: u32 = 0xdead_beef;
         assert_err!(None::<bool>.expect_kv("id", id));
         assert!(Some(true).expect_kv("id", id).unwrap());
 


### PR DESCRIPTION
* Added method to lazily propagate `NotFound` errors with attachments that require allocation:
  https://github.com/knox-networks/bigerror/blob/743e63486d7c9d8c0ad94c31c37d928f32c1c322/src/lib.rs#L694-L700

* `attachment::Index`  and `attachment:Type` wrappers now use the `simple_type_name` function to handle error reporting:
  https://github.com/knox-networks/bigerror/blob/b7db923d70f0c6b339618f11b5b4c08925834fea/src/attachment.rs#L240-L243